### PR TITLE
Some improvements in the code, with generics and type inference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #![recursion_limit = "1024"]
 
-#![feature(repeat_str, test)]
 extern crate byteorder;
-extern crate test;
 extern crate quick_xml;
 #[macro_use]
 extern crate error_chain;
@@ -67,7 +65,8 @@ mod tests {
         let out = decoder.as_xml(&xml_content).unwrap();
 
         let inner_expected = "<start_tag></start_tag>";
-        let expected = format!("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n{}", inner_expected);
+        let expected = format!("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n{}",
+                               inner_expected);
 
         assert_eq!(expected, out);
     }

--- a/src/model/element.rs
+++ b/src/model/element.rs
@@ -45,7 +45,7 @@ impl Element {
 
 impl Display for Element {
     fn fmt(&self, formatter: &mut Formatter) -> StdResult<(), FmtError> {
-        let tabs = "\t".to_string().repeat(self.level as usize);
+        let tabs = "\t".repeat(self.level as usize);
         write!(formatter, "{}Element: {}\n", tabs, self.tag)?;
 
         for c in &self.children {
@@ -69,7 +69,8 @@ impl ElementContainer {
     }
 
     pub fn end_element(&mut self) {
-        self.stack.pop()
+        self.stack
+            .pop()
             .and_then(|element| {
                 if self.stack.is_empty() {
                     self.root = Some(element);


### PR DESCRIPTION
So, I saw that you are not using much generics, that would enable much easier coding for library users. Added also some type inference with cursors, removed an unnecessary allocation in the heap and removed feature flags, so that this now compiles on beta, and will compile on stable as for March 16th.

I saw a few details in the code though. The `Decoder` type does not own its data, which I cannot completelly understand. The buffer itself is created outside the `Apk`, which an be a headache for users. I would say that the vector should be allocated by the `Apk`/`Decoder` and then be stored as a `Box<[u8]>`, to deallocate some RAM. This can then be used in a `Cursor`, of course.

Also, there should be a way for creating a decoder from a `Read` object. This is a must for SUPER, since we will only open the zip file once, and then give the library a mere `Read` object to generate its buffers and so on.

I also saw some tests using `vec![CONSTANT VALUES]` and then comparing them to a slice. There is no need for that, you can simply create arrays in the stack. I didn't include those fixes in the first commit because since they are tests it's not a big deal for the library, but I can add them if you want me to.

I can also try to fix formatting.