### PR TITLE
Reworked external api

### DIFF
--- a/examples/converter.rs
+++ b/examples/converter.rs
@@ -62,8 +62,6 @@ fn run() -> Result<()> {
     let mut resources_content = Vec::new();
     archive.by_name("resources.arsc").unwrap().read_to_end(&mut resources_content)?;
 
-    let resources_cursor: Cursor<&[u8]> = Cursor::new(&resources_content);
-    let android_resources_cursor: Cursor<&[u8]> = Cursor::new(&android_resources_content);
     let mut resources_visitor = ModelVisitor::default();
     Executor::arsc(&resources_content, &mut resources_visitor)?;
     Executor::arsc(&android_resources_content, &mut resources_visitor)?;

--- a/examples/converter.rs
+++ b/examples/converter.rs
@@ -65,8 +65,8 @@ fn run() -> Result<()> {
     let resources_cursor: Cursor<&[u8]> = Cursor::new(&resources_content);
     let android_resources_cursor: Cursor<&[u8]> = Cursor::new(&android_resources_content);
     let mut resources_visitor = ModelVisitor::default();
-    Executor::arsc(resources_cursor, &mut resources_visitor)?;
-    Executor::arsc(android_resources_cursor, &mut resources_visitor)?;
+    Executor::arsc(&resources_content, &mut resources_visitor)?;
+    Executor::arsc(&android_resources_content, &mut resources_visitor)?;
 
     for i in 0..archive.len() {
         let mut current_file = archive.by_index(i).unwrap();

--- a/examples/exporter.rs
+++ b/examples/exporter.rs
@@ -50,9 +50,11 @@ fn run() -> Result<()> {
         }
     };
 
+    // TODO: Export
+/*
     let path = Path::new(&apk_path);
     let mut apk = Apk::new(path).chain_err(|| "Error loading APK")?;
-    apk.export(Path::new(&output), true).chain_err(|| "APK could not be exported")?;
-
+    apk.export(decoder, Path::new(&output), true).chain_err(|| "APK could not be exported")?;
+*/
     Ok(())
 }

--- a/examples/exporter.rs
+++ b/examples/exporter.rs
@@ -8,6 +8,7 @@ extern crate env_logger;
 use std::env;
 use abxml::errors::*;
 use std::path::Path;
+use abxml::decoder::Apk;
 
 fn main() {
     env_logger::init().unwrap();
@@ -49,11 +50,9 @@ fn run() -> Result<()> {
         }
     };
 
-    // TODO: Export
-/*
     let path = Path::new(&apk_path);
     let mut apk = Apk::new(path).chain_err(|| "Error loading APK")?;
-    apk.export(decoder, Path::new(&output), true).chain_err(|| "APK could not be exported")?;
-*/
+    apk.export(Path::new(&output), true).chain_err(|| "APK could not be exported")?;
+
     Ok(())
 }

--- a/examples/exporter.rs
+++ b/examples/exporter.rs
@@ -51,9 +51,7 @@ fn run() -> Result<()> {
     };
 
     let path = Path::new(&apk_path);
-    let mut buffer = Vec::new();
-
-    let mut apk = Apk::new(path, &mut buffer).chain_err(|| "Error loading APK")?;
+    let mut apk = Apk::new(path).chain_err(|| "Error loading APK")?;
     apk.export(Path::new(&output), true).chain_err(|| "APK could not be exported")?;
 
     Ok(())

--- a/examples/exporter.rs
+++ b/examples/exporter.rs
@@ -7,7 +7,6 @@ extern crate env_logger;
 
 use std::env;
 use abxml::errors::*;
-use abxml::decoder::Apk;
 use std::path::Path;
 
 fn main() {

--- a/src/chunks/mod.rs
+++ b/src/chunks/mod.rs
@@ -83,8 +83,6 @@ impl<'a> ChunkLoaderStream<'a> {
         let chunk_size = self.cursor.read_u32::<LittleEndian>()?;
         let chunk_header = ChunkHeader::new(initial_position, header_size, chunk_size, token);
 
-        println!("Token: {:X}", token);
-
         let chunk = match token {
             TOKEN_STRING_TABLE => StringTableDecoder::decode(&mut self.cursor, &chunk_header)?,
             TOKEN_PACKAGE => PackageDecoder::decode(&mut self.cursor, &chunk_header)?,
@@ -122,7 +120,7 @@ impl<'a> Iterator for ChunkLoaderStream<'a> {
     type Item = Result<Chunk<'a>>;
 
     fn next(&mut self) -> Option<Result<Chunk<'a>>> {
-        if self.cursor.position() == self.cursor.get_ref().len() as u64 {
+        if self.cursor.position() >= self.cursor.get_ref().len() as u64 {
             return None;
         }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -6,6 +6,22 @@ use visitor::*;
 use encoder::Xml;
 use STR_ARSC;
 
+pub struct OwnedDecoder {
+    buffer: Vec<u8>,
+}
+
+impl OwnedDecoder {
+    pub fn new(buffer: Vec<u8>) -> OwnedDecoder {
+        OwnedDecoder {
+            buffer: buffer,
+        }
+    }
+
+    pub fn get_decoder(&self) -> Result<Decoder> {
+        Decoder::new(&self.buffer)
+    }
+}
+
 pub struct Decoder<'a> {
     visitor: ModelVisitor<'a>,
     buffer_android: &'a [u8],
@@ -49,12 +65,12 @@ impl<'a> Decoder<'a> {
                             .chain_err(|| "Could note encode XML");
                     }
                     None => {
-                        println!("No string table found");
+                        warn!("No string table found");
                     }
                 }
             }
             None => {
-                println!("No root on target XML");
+                warn!("No root on target XML");
             }
         }
 
@@ -149,3 +165,21 @@ impl Apk {
     }
 }
 */
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_not_decode_an_empty_binary_xml() {
+        // Empty resources.arsc file
+        let buffer = vec![0,0, 12,0, 0,0,0,0, 0,0,0,0];
+
+        let owned = OwnedDecoder::new(buffer);
+        let decoder = owned.get_decoder().unwrap();
+
+        // Empty binary XML file
+        let another = vec![0,0, 0, 0, 0, 0, 0, 0];
+        assert!(decoder.as_xml(&another).is_err());
+    }
+}

--- a/src/model/builder.rs
+++ b/src/model/builder.rs
@@ -99,7 +99,7 @@ mod tests {
 
         assert_eq!(vec![0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0], content);
 
-        Executor::arsc(Cursor::new(&content), &mut visitor).unwrap();
+        Executor::arsc(&content, &mut visitor).unwrap();
 
         assert_eq!(0, visitor.get_count());
     }
@@ -115,7 +115,7 @@ mod tests {
         let content = arsc.to_vec().unwrap();
         let mut visitor = CounterChunkVisitor::new();
 
-        Executor::arsc(Cursor::new(&content), &mut visitor).unwrap();
+        Executor::arsc(&content, &mut visitor).unwrap();
 
         // Resource should be ignored as it is not a chunk that appears on an ARSC
         assert_eq!(2, visitor.get_count());

--- a/src/visitor/mod.rs
+++ b/src/visitor/mod.rs
@@ -28,9 +28,10 @@ pub trait ChunkVisitor<'a> {
 pub struct Executor;
 
 impl Executor {
-    pub fn arsc<'a, V: ChunkVisitor<'a>>(mut cursor: Cursor<&'a [u8]>,
+    pub fn arsc<'a, V: ChunkVisitor<'a>>(buffer: &'a [u8],
                                          mut visitor: &mut V)
                                          -> Result<()> {
+        let mut cursor = Cursor::new(buffer);
         let _token = cursor.read_u16::<LittleEndian>().chain_err(|| "Error reading first token")?;
         let _header_size = cursor.read_u16::<LittleEndian>()
             .chain_err(|| "Error reading header size")?;

--- a/src/visitor/mod.rs
+++ b/src/visitor/mod.rs
@@ -39,6 +39,7 @@ impl Executor {
             .chain_err(|| "Error reading chunk size")?;
         let _package_amount = cursor.read_u32::<LittleEndian>()
             .chain_err(|| "Error reading package amount")?;
+        // TODO: Avoid infinite loop
         cursor.set_position(_header_size as u64);
 
         let stream = ChunkLoaderStream::new(cursor);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -27,8 +27,7 @@ fn it_can_generate_a_decoder_from_a_buffer() {
     xml.push_owned(Box::new(XmlTagEndBuf::new(90)));
 
     let xml_content = xml.into_vec().unwrap();
-    let cow_arsc = Cow::from(arsc);
-    let decoder = Decoder::new(cow_arsc).unwrap();
+    let decoder = Decoder::new(&arsc).unwrap();
     let out = decoder.as_xml(&xml_content).unwrap();
 
     let inner_expected = "<start_tag></start_tag>";

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,10 +1,8 @@
 extern crate abxml;
 
-use std::path::Path;
 use abxml::decoder::Decoder;
 use abxml::model::builder::Xml;
 use abxml::model::owned::{XmlTagStartBuf, XmlTagEndBuf, StringTableBuf};
-use std::borrow::Cow;
 
 #[test]
 fn it_can_generate_a_decoder_from_a_buffer() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,19 +4,18 @@ use std::path::Path;
 use abxml::decoder::{Apk, Decoder};
 use abxml::model::builder::Xml;
 use abxml::model::owned::{XmlTagStartBuf, XmlTagEndBuf, StringTableBuf};
+use std::borrow::Cow;
 
 #[test]
 #[should_panic]
 fn it_can_generate_a_decoder_from_an_apk() {
     let path = Path::new("some.apk");
-    let mut buffer = Vec::new();
-
-    Apk::new(path, &mut buffer).unwrap();
+    Apk::new(path).unwrap();
 }
 
 #[test]
 fn it_can_generate_a_decoder_from_a_buffer() {
-    let arsc = [0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    let arsc = vec![0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0];
     let mut xml = Xml::default();
     let mut st = StringTableBuf::default();
     st.add_string("Some string".to_string());
@@ -28,8 +27,8 @@ fn it_can_generate_a_decoder_from_a_buffer() {
     xml.push_owned(Box::new(XmlTagEndBuf::new(90)));
 
     let xml_content = xml.into_vec().unwrap();
-
-    let decoder = Decoder::new(&arsc).unwrap();
+    let cow_arsc = Cow::from(arsc);
+    let decoder = Decoder::new(cow_arsc).unwrap();
     let out = decoder.as_xml(&xml_content).unwrap();
 
     let inner_expected = "<start_tag></start_tag>";

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,17 +1,10 @@
 extern crate abxml;
 
 use std::path::Path;
-use abxml::decoder::{Apk, Decoder};
+use abxml::decoder::Decoder;
 use abxml::model::builder::Xml;
 use abxml::model::owned::{XmlTagStartBuf, XmlTagEndBuf, StringTableBuf};
 use std::borrow::Cow;
-
-#[test]
-#[should_panic]
-fn it_can_generate_a_decoder_from_an_apk() {
-    let path = Path::new("some.apk");
-    Apk::new(path).unwrap();
-}
 
 #[test]
 fn it_can_generate_a_decoder_from_a_buffer() {


### PR DESCRIPTION
Reworked a little bit the external API to avoid the need to pass a mutable vector as a buffer for the apk's resources.arsc.

Introduced the `BufferedDecoder` to be able to create a decoder from non-slice sources and allocating itself a buffer (from Read) or given an owned buffer (fromVec).

Pending add some generics with From/Into