### PR TITLE
Cache for string table

### DIFF
--- a/examples/converter.rs
+++ b/examples/converter.rs
@@ -97,12 +97,16 @@ fn parse_xml<'a>(content: &[u8], resources: &'a Resources<'a>) -> Result<String>
     match *visitor.get_root() {
         Some(ref root) => {
             match *visitor.get_string_table() {
-                Some(_) => {
-                    return Xml::encode(visitor.get_namespaces(),
-                                       root,
-                                       visitor.get_resources(),
-                                       resources)
-                                   .chain_err(|| "Could note encode XML");
+                Some(ref st) => {
+                    let encoded = Xml::encode(visitor.get_namespaces(),
+                                              root,
+                                              visitor.get_resources(),
+                                              resources)
+                            .chain_err(|| "Could note encode XML");
+
+                    st.display_stats();
+
+                    return encoded;
                 }
                 None => {
                     println!("No string table found");

--- a/examples/converter.rs
+++ b/examples/converter.rs
@@ -98,15 +98,11 @@ fn parse_xml<'a>(content: &[u8], resources: &'a Resources<'a>) -> Result<String>
         Some(ref root) => {
             match *visitor.get_string_table() {
                 Some(ref st) => {
-                    let encoded = Xml::encode(visitor.get_namespaces(),
-                                              root,
-                                              visitor.get_resources(),
-                                              resources)
-                            .chain_err(|| "Could note encode XML");
-
-                    st.display_stats();
-
-                    return encoded;
+                    return Xml::encode(visitor.get_namespaces(),
+                                       root,
+                                       visitor.get_resources(),
+                                       resources)
+                                   .chain_err(|| "Could note encode XML");
                 }
                 None => {
                     println!("No string table found");

--- a/src/chunks/mod.rs
+++ b/src/chunks/mod.rs
@@ -11,6 +11,7 @@ mod xml;
 
 pub use self::string_table::StringTableDecoder;
 pub use self::string_table::StringTableWrapper;
+pub use self::string_table::CountingStringTable;
 pub use self::chunk_header::ChunkHeader;
 pub use self::package::PackageWrapper;
 pub use self::table_type_spec::TypeSpecWrapper;

--- a/src/chunks/mod.rs
+++ b/src/chunks/mod.rs
@@ -11,7 +11,7 @@ mod xml;
 
 pub use self::string_table::StringTableDecoder;
 pub use self::string_table::StringTableWrapper;
-pub use self::string_table::CountingStringTable;
+pub use self::string_table::StringTableCache;
 pub use self::chunk_header::ChunkHeader;
 pub use self::package::PackageWrapper;
 pub use self::table_type_spec::TypeSpecWrapper;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -67,8 +67,8 @@ pub trait Library {
                         -> Result<String>;
     // fn get_entries(&self) -> &Entries;
     fn get_entry(&self, id: u32) -> Result<&Entry>;
-    fn get_entries_string(&self, str_id: u32) -> Result<String>;
-    fn get_spec_string(&self, str_id: u32) -> Result<String>;
+    fn get_entries_string(&self, str_id: u32) -> Result<Rc<String>>;
+    fn get_spec_string(&self, str_id: u32) -> Result<Rc<String>>;
 }
 
 pub trait LibraryBuilder<'a> {

--- a/src/visitor/xml.rs
+++ b/src/visitor/xml.rs
@@ -17,7 +17,7 @@ use super::ChunkVisitor;
 use super::Origin;
 
 pub struct XmlVisitor<'a> {
-    main_string_table: Option<CountingStringTable<StringTableWrapper<'a>>>,
+    main_string_table: Option<StringTableCache<StringTableWrapper<'a>>>,
     namespaces: Namespaces,
     container: ElementContainer,
     res: Vec<u32>,
@@ -43,7 +43,7 @@ impl<'a> XmlVisitor<'a> {
         self.container.get_root()
     }
 
-    pub fn get_string_table(&self) -> &Option<CountingStringTable<StringTableWrapper<'a>>> {
+    pub fn get_string_table(&self) -> &Option<StringTableCache<StringTableWrapper<'a>>> {
         &self.main_string_table
     }
 
@@ -92,7 +92,7 @@ impl<'a> XmlVisitor<'a> {
     }
 
     fn get_element_data(&self,
-                        string_table: &CountingStringTable<StringTableWrapper<'a>>,
+                        string_table: &StringTableCache<StringTableWrapper<'a>>,
                         tag_start: &XmlTagStartWrapper)
                         -> Result<(String, HashMap<String, String>)> {
         let name_index = tag_start.get_element_name_index().chain_err(|| "Name index not found")?;
@@ -164,7 +164,7 @@ impl<'a> ChunkVisitor<'a> for XmlVisitor<'a> {
                 error!("Secondary table!");
             }
             None => {
-                self.main_string_table = Some(CountingStringTable::new(string_table));
+                self.main_string_table = Some(StringTableCache::new(string_table));
             }
         }
     }

--- a/src/visitor/xml.rs
+++ b/src/visitor/xml.rs
@@ -17,7 +17,7 @@ use super::ChunkVisitor;
 use super::Origin;
 
 pub struct XmlVisitor<'a> {
-    main_string_table: Option<StringTableWrapper<'a>>,
+    main_string_table: Option<CountingStringTable<StringTableWrapper<'a>>>,
     namespaces: Namespaces,
     container: ElementContainer,
     res: Vec<u32>,
@@ -43,7 +43,7 @@ impl<'a> XmlVisitor<'a> {
         self.container.get_root()
     }
 
-    pub fn get_string_table(&self) -> &Option<StringTableWrapper> {
+    pub fn get_string_table(&self) -> &Option<CountingStringTable<StringTableWrapper<'a>>> {
         &self.main_string_table
     }
 
@@ -92,7 +92,7 @@ impl<'a> XmlVisitor<'a> {
     }
 
     fn get_element_data(&self,
-                        string_table: &StringTableWrapper,
+                        string_table: &CountingStringTable<StringTableWrapper<'a>>,
                         tag_start: &XmlTagStartWrapper)
                         -> Result<(String, HashMap<String, String>)> {
         let name_index = tag_start.get_element_name_index().chain_err(|| "Name index not found")?;
@@ -164,7 +164,7 @@ impl<'a> ChunkVisitor<'a> for XmlVisitor<'a> {
                 error!("Secondary table!");
             }
             None => {
-                self.main_string_table = Some(string_table);
+                self.main_string_table = Some(CountingStringTable::new(string_table));
             }
         }
     }

--- a/src/visitor/xml.rs
+++ b/src/visitor/xml.rs
@@ -272,7 +272,7 @@ impl AttributeHelper {
         let str_indexes = Self::get_strings(flags, entry_ref, package);
         let str_strs: Vec<String> = str_indexes.iter()
             .map(|si| match package.get_entries_string(*si) {
-                     Ok(str) => str,
+                     Ok(str) => (*str).clone(),
                      Err(_) => {
                 error!("Key not found on the string table");
 
@@ -445,13 +445,13 @@ mod tests {
             self.entries.get(&id).ok_or_else(|| "Could not find entry".into())
         }
 
-        fn get_entries_string(&self, str_id: u32) -> Result<String> {
+        fn get_entries_string(&self, str_id: u32) -> Result<Rc<String>> {
             let st = FakeStringTable;
 
-            Ok((*st.get_string(str_id)?).clone())
+            Ok(st.get_string(str_id)?)
         }
 
-        fn get_spec_string(&self, _: u32) -> Result<String> {
+        fn get_spec_string(&self, _: u32) -> Result<Rc<String>> {
             Err("Sepc string".into())
         }
     }


### PR DESCRIPTION
Try to minimize the parsing/allocations by saving the Rc<String> on a HashMap.
This seems to be penalizing at the moment, even I've checked that there are some strings that are get multiple times.

This needs more investigation on why there's a penalitzation (~100ms more, out of ~780ms) when the cache is used.