### PR TITLE
Avoid try to decode raw XML files

### DIFF
--- a/examples/converter.rs
+++ b/examples/converter.rs
@@ -79,7 +79,8 @@ fn run() -> Result<()> {
                 let new_content = xml_content.clone();
 
                 let resources = resources_visitor.get_resources();
-                let out = parse_xml(&new_content, resources).unwrap();
+                let out = parse_xml(&new_content, resources)
+                    .chain_err(|| "Could not decode target file")?;
                 println!("{}", out);
             }
         }

--- a/src/apk.rs
+++ b/src/apk.rs
@@ -57,12 +57,11 @@ impl Apk {
             let contents = if (file_name.starts_with("res/") && file_name.ends_with(".xml")) ||
                               file_name == "AndroidManifest.xml" {
 
-                let xml_visitor = decoder.xml_visitor(&contents)
-                    .chain_err(|| "Could not decode the target file")?;
-                let out = xml_visitor.into_string()
-                    .chain_err(|| format!("Could not decode: {}", file_name))?;
+                decoder.xml_visitor(&contents)
+                    .and_then(|visitor| visitor.into_string())
+                    .and_then(|string| Ok(string.into_bytes()))
+                    .unwrap_or(contents)
 
-                out.into_bytes()
             } else {
                 contents
             };

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -80,20 +80,20 @@ mod tests {
     #[test]
     fn it_can_not_decode_an_empty_binary_xml() {
         // Empty resources.arsc file
-        let buffer = vec![0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let buffer = vec![2, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
         let owned = BufferedDecoder::from(buffer);
         let decoder = owned.get_decoder().unwrap();
 
         // Empty binary XML file
-        let another = vec![0, 0, 0, 0, 0, 0, 0, 0];
+        let another = vec![3, 0, 0, 0, 0, 0, 0, 0];
         let xml_result = decoder.xml_visitor(&another).unwrap().into_string();
         assert!(xml_result.is_err());
     }
 
     #[test]
     fn it_can_create_a_buffer_decoder_from_read() {
-        let buffer = vec![0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let buffer = vec![2, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
         let owned = BufferedDecoder::from_read(Cursor::new(buffer)).unwrap();
         let _ = owned.get_decoder().unwrap();

--- a/src/model/builder.rs
+++ b/src/model/builder.rs
@@ -24,9 +24,8 @@ impl Arsc {
             inner.extend(encoded_chunk);
         }
 
-        // TODO: Check initial token
         // Token
-        out.write_u16::<LittleEndian>(0)?;
+        out.write_u16::<LittleEndian>(2)?;
 
         // Header_size
         out.write_u16::<LittleEndian>(3 * 4)?;
@@ -66,12 +65,11 @@ impl Xml {
             inner.extend(encoded_chunk);
         }
 
-        // TODO: Check initial token
         // Token
-        out.write_u16::<LittleEndian>(0)?;
+        out.write_u16::<LittleEndian>(3)?;
 
         // Header_size
-        out.write_u16::<LittleEndian>(3 * 4)?;
+        out.write_u16::<LittleEndian>(2 * 4)?;
 
         // Chunk size
         out.write_u32::<LittleEndian>(file_size as u32)?;
@@ -97,7 +95,7 @@ mod tests {
         let content = arsc.to_vec().unwrap();
         let mut visitor = CounterChunkVisitor::new();
 
-        assert_eq!(vec![0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0], content);
+        assert_eq!(vec![2, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0], content);
 
         Executor::arsc(&content, &mut visitor).unwrap();
 
@@ -127,7 +125,7 @@ mod tests {
         let content = xml.into_vec().unwrap();
         let mut visitor = CounterChunkVisitor::new();
 
-        assert_eq!(vec![0, 0, 12, 0, 0, 0, 0, 0], content);
+        assert_eq!(vec![3, 0, 8, 0, 0, 0, 0, 0], content);
 
         Executor::xml(Cursor::new(&content), &mut visitor).unwrap();
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -6,7 +6,7 @@ use abxml::model::owned::{XmlTagStartBuf, XmlTagEndBuf, StringTableBuf, Attribut
 
 #[test]
 fn it_can_generate_a_decoder_from_a_buffer() {
-    let arsc = vec![0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    let arsc = vec![2, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0];
     let mut xml = Xml::default();
     let mut st = StringTableBuf::default();
     st.add_string("Some string".to_string());


### PR DESCRIPTION
APK exporting tries to decode all .xml files on '/res' folder. In case that there's some string XML file (not binary), it tried to decode it anyway.

- Added some checks (the initial token) to know if it can be decoded or not.
- Changed the export behaviour: if there's some error decoding a single file, we export the non-decoded version. If we could do the conversion, export the decoded version