### PR TITLE
Remove all decoders and let wrappers to only work with the minimum data

### DIFF
--- a/src/chunks/chunk_header.rs
+++ b/src/chunks/chunk_header.rs
@@ -43,6 +43,10 @@ impl ChunkHeader {
 
         absolute
     }
+
+    pub fn get_token(&self) -> u16 {
+        self.chunk_type
+    }
 }
 
 impl fmt::Display for ChunkHeader {

--- a/src/chunks/package.rs
+++ b/src/chunks/package.rs
@@ -1,43 +1,28 @@
-use chunks::{Chunk, ChunkHeader};
 use std::io::Cursor;
 use byteorder::{LittleEndian, ReadBytesExt};
 use errors::*;
 use encoding::codec::utf_16;
 use encoding::codec::utf_16::Little;
 
-pub struct PackageDecoder;
-
-impl PackageDecoder {
-    pub fn decode<'a>(cursor: &mut Cursor<&'a [u8]>, header: &ChunkHeader) -> Result<Chunk<'a>> {
-        let pw = PackageWrapper::new(cursor.get_ref(), *header);
-
-        Ok(Chunk::Package(pw))
-    }
-}
-
 pub struct PackageWrapper<'a> {
     raw_data: &'a [u8],
-    header: ChunkHeader,
 }
 
 impl<'a> PackageWrapper<'a> {
-    pub fn new(raw_data: &'a [u8], header: ChunkHeader) -> Self {
-        PackageWrapper {
-            raw_data: raw_data,
-            header: header,
-        }
+    pub fn new(slice: &'a [u8]) -> Self {
+        PackageWrapper { raw_data: slice }
     }
 
     pub fn get_id(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(8));
+        cursor.set_position(8);
 
         Ok(cursor.read_u32::<LittleEndian>()?)
     }
 
     pub fn get_name(&self) -> Result<String> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(12));
+        cursor.set_position(12);
         let initial_position = cursor.position();
         let final_position = self.find_end_position(initial_position as usize);
 

--- a/src/chunks/resource.rs
+++ b/src/chunks/resource.rs
@@ -1,35 +1,21 @@
-use chunks::{Chunk, ChunkHeader};
 use std::io::Cursor;
 use byteorder::{LittleEndian, ReadBytesExt};
 use errors::*;
 use model::owned::ResourcesBuf;
 
-pub struct ResourceDecoder;
-
-impl ResourceDecoder {
-    pub fn decode<'a>(cursor: &mut Cursor<&'a [u8]>, header: &ChunkHeader) -> Result<Chunk<'a>> {
-        let ttw = ResourceWrapper::new(cursor.get_ref(), *header);
-        Ok(Chunk::Resource(ttw))
-    }
-}
-
 #[allow(dead_code)]
 pub struct ResourceWrapper<'a> {
     raw_data: &'a [u8],
-    header: ChunkHeader,
 }
 
 impl<'a> ResourceWrapper<'a> {
-    pub fn new(raw_data: &'a [u8], header: ChunkHeader) -> Self {
-        ResourceWrapper {
-            raw_data: raw_data,
-            header: header,
-        }
+    pub fn new(raw_data: &'a [u8]) -> Self {
+        ResourceWrapper { raw_data: raw_data }
     }
 
     pub fn get_resources(&self) -> Result<Vec<u32>> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(4));
+        cursor.set_position(4);
 
         let count = cursor.read_u32::<LittleEndian>()?;
         let mut resources = Vec::with_capacity(count as usize);
@@ -57,7 +43,6 @@ impl<'a> ResourceWrapper<'a> {
 mod tests {
     use super::*;
     use model::owned::ResourcesBuf;
-    use chunks::*;
     use model::owned::OwnedBuf;
 
     #[test]
@@ -69,24 +54,7 @@ mod tests {
 
         out[4] = 255;
 
-        let chunk_header = ChunkHeader::new(0, 8, 255, 0x0180);
-        let wrapper = ResourceWrapper::new(&out, chunk_header);
-
-        let result = wrapper.get_resources();
-        assert!(result.is_err());
-        assert_eq!("failed to fill whole buffer",
-                   result.err().unwrap().to_string());
-    }
-
-    #[test]
-    fn it_can_not_decode_a_buffer_if_chunk_header_is_not_correct() {
-        let mut resources = ResourcesBuf::default();
-        resources.push_resource(111);
-        resources.push_resource(222);
-        let out = resources.to_vec().unwrap();
-
-        let chunk_header = ChunkHeader::new(3000, 8, 2 * 4, 0x0180);
-        let wrapper = ResourceWrapper::new(&out, chunk_header);
+        let wrapper = ResourceWrapper::new(&out);
 
         let result = wrapper.get_resources();
         assert!(result.is_err());

--- a/src/chunks/xml.rs
+++ b/src/chunks/xml.rs
@@ -8,68 +8,25 @@ use model::owned::{XmlTagStartBuf, XmlTagEndBuf, XmlNamespaceStartBuf, XmlNamesp
                    AttributeBuf};
 use model::{TagStart, TagEnd, NamespaceStart, NamespaceEnd, AttributeTrait};
 
-pub struct XmlDecoder;
-
-impl XmlDecoder {
-    pub fn decode_xml_namespace_start<'a>(cursor: &mut Cursor<&'a [u8]>,
-                                          header: &ChunkHeader)
-                                          -> Result<Chunk<'a>> {
-        let xnsw = XmlNamespaceStartWrapper::new(cursor.get_ref(), *header);
-        Ok(Chunk::XmlNamespaceStart(xnsw))
-    }
-
-    pub fn decode_xml_namespace_end<'a>(cursor: &mut Cursor<&'a [u8]>,
-                                        header: &ChunkHeader)
-                                        -> Result<Chunk<'a>> {
-        let xnsw = XmlNamespaceEndWrapper::new(cursor.get_ref(), *header);
-        Ok(Chunk::XmlNamespaceEnd(xnsw))
-    }
-
-    pub fn decode_xml_tag_start<'a>(cursor: &mut Cursor<&'a [u8]>,
-                                    header: &ChunkHeader)
-                                    -> Result<Chunk<'a>> {
-        let xnsw = XmlTagStartWrapper::new(cursor.get_ref(), *header);
-        Ok(Chunk::XmlTagStart(xnsw))
-    }
-
-    pub fn decode_xml_tag_end<'a>(cursor: &mut Cursor<&'a [u8]>,
-                                  header: &ChunkHeader)
-                                  -> Result<Chunk<'a>> {
-        let xnsw = XmlTagEndWrapper::new(cursor.get_ref(), *header);
-        Ok(Chunk::XmlTagEnd(xnsw))
-    }
-
-    pub fn decode_xml_text<'a>(cursor: &mut Cursor<&'a [u8]>,
-                               header: &ChunkHeader)
-                               -> Result<Chunk<'a>> {
-        let xnsw = XmlTextWrapper::new(cursor.get_ref(), *header);
-        Ok(Chunk::XmlText(xnsw))
-    }
-}
-
 pub struct XmlNamespaceStartWrapper<'a> {
     raw_data: &'a [u8],
-    header: ChunkHeader,
 }
 
 impl<'a> XmlNamespaceStartWrapper<'a> {
-    pub fn new(raw_data: &'a [u8], header: ChunkHeader) -> Self {
-        XmlNamespaceStartWrapper {
-            raw_data: raw_data,
-            header: header,
-        }
+    pub fn new(raw_data: &'a [u8]) -> Self {
+        XmlNamespaceStartWrapper { raw_data: raw_data }
     }
 
     pub fn get_prefix_index(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(16));
+        cursor.set_position(16);
 
         Ok(cursor.read_u32::<LittleEndian>()?)
     }
 
     pub fn get_namespace_index(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(20));
+        cursor.set_position(20);
 
         Ok(cursor.read_u32::<LittleEndian>()?)
     }
@@ -100,7 +57,7 @@ impl<'a> NamespaceStart for XmlNamespaceStartWrapper<'a> {
 
     fn get_line(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(8));
+        cursor.set_position(8);
 
         Ok(cursor.read_u32::<LittleEndian>()?)
     }
@@ -109,27 +66,23 @@ impl<'a> NamespaceStart for XmlNamespaceStartWrapper<'a> {
 #[allow(dead_code)]
 pub struct XmlNamespaceEndWrapper<'a> {
     raw_data: &'a [u8],
-    header: ChunkHeader,
 }
 
 impl<'a> XmlNamespaceEndWrapper<'a> {
-    pub fn new(raw_data: &'a [u8], header: ChunkHeader) -> Self {
-        XmlNamespaceEndWrapper {
-            raw_data: raw_data,
-            header: header,
-        }
+    pub fn new(raw_data: &'a [u8]) -> Self {
+        XmlNamespaceEndWrapper { raw_data: raw_data }
     }
 
     pub fn get_prefix_index(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(16));
+        cursor.set_position(16);
 
         Ok(cursor.read_u32::<LittleEndian>()?)
     }
 
     pub fn get_namespace_index(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(20));
+        cursor.set_position(20);
 
         Ok(cursor.read_u32::<LittleEndian>()?)
     }
@@ -146,7 +99,7 @@ impl<'a> XmlNamespaceEndWrapper<'a> {
 impl<'a> NamespaceEnd for XmlNamespaceEndWrapper<'a> {
     fn get_line(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(8));
+        cursor.set_position(8);
 
         Ok(cursor.read_u32::<LittleEndian>()?)
     }
@@ -169,7 +122,6 @@ impl<'a> NamespaceEnd for XmlNamespaceEndWrapper<'a> {
 /// Contains a reference to the whole buffer and the chunk header of a `TagStart`
 pub struct XmlTagStartWrapper<'a> {
     raw_data: &'a [u8],
-    header: ChunkHeader,
 }
 
 impl<'a> TagStart for XmlTagStartWrapper<'a> {
@@ -177,7 +129,7 @@ impl<'a> TagStart for XmlTagStartWrapper<'a> {
 
     fn get_line(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(8));
+        cursor.set_position(8);
 
         cursor
             .read_u32::<LittleEndian>()
@@ -186,7 +138,7 @@ impl<'a> TagStart for XmlTagStartWrapper<'a> {
 
     fn get_field1(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(12));
+        cursor.set_position(12);
 
         cursor
             .read_u32::<LittleEndian>()
@@ -195,7 +147,7 @@ impl<'a> TagStart for XmlTagStartWrapper<'a> {
 
     fn get_namespace_index(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(16));
+        cursor.set_position(16);
 
         cursor
             .read_u32::<LittleEndian>()
@@ -204,7 +156,7 @@ impl<'a> TagStart for XmlTagStartWrapper<'a> {
 
     fn get_element_name_index(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(20));
+        cursor.set_position(20);
 
         cursor
             .read_u32::<LittleEndian>()
@@ -213,7 +165,7 @@ impl<'a> TagStart for XmlTagStartWrapper<'a> {
 
     fn get_field2(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(24));
+        cursor.set_position(24);
 
         cursor
             .read_u32::<LittleEndian>()
@@ -222,7 +174,7 @@ impl<'a> TagStart for XmlTagStartWrapper<'a> {
 
     fn get_attributes_amount(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(28));
+        cursor.set_position(28);
 
         cursor
             .read_u32::<LittleEndian>()
@@ -231,7 +183,7 @@ impl<'a> TagStart for XmlTagStartWrapper<'a> {
 
     fn get_class(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(32));
+        cursor.set_position(32);
 
         cursor
             .read_u32::<LittleEndian>()
@@ -240,8 +192,8 @@ impl<'a> TagStart for XmlTagStartWrapper<'a> {
 
     fn get_attribute(&self, index: u32) -> Result<Self::Attribute> {
         let offset = 36 + (index * (5 * 4)) as u64;
-        let initial_position: usize = self.header.absolute(offset) as usize;
-        let final_position: usize = self.header.absolute(offset + (5 * 4)) as usize;
+        let initial_position: usize = offset as usize;
+        let final_position: usize = (offset + (5 * 4)) as usize;
         let slice = &self.raw_data[initial_position..final_position];
 
         let out = AttributeWrapper::new(slice);
@@ -252,11 +204,8 @@ impl<'a> TagStart for XmlTagStartWrapper<'a> {
 
 impl<'a> XmlTagStartWrapper<'a> {
     /// Creates a new `XmlTagStartWrapper`
-    pub fn new(raw_data: &'a [u8], header: ChunkHeader) -> Self {
-        XmlTagStartWrapper {
-            raw_data: raw_data,
-            header: header,
-        }
+    pub fn new(raw_data: &'a [u8]) -> Self {
+        XmlTagStartWrapper { raw_data: raw_data }
     }
 
     /// It converts the wrapper into a `XmlTagStartBuf` which can be later manipulated
@@ -351,15 +300,11 @@ impl<'a> AttributeWrapper<'a> {
 #[allow(dead_code)]
 pub struct XmlTagEndWrapper<'a> {
     raw_data: &'a [u8],
-    header: ChunkHeader,
 }
 
 impl<'a> XmlTagEndWrapper<'a> {
-    pub fn new(raw_data: &'a [u8], header: ChunkHeader) -> Self {
-        XmlTagEndWrapper {
-            raw_data: raw_data,
-            header: header,
-        }
+    pub fn new(raw_data: &'a [u8]) -> Self {
+        XmlTagEndWrapper { raw_data: raw_data }
     }
 
     pub fn to_buffer(&self) -> Result<XmlTagEndBuf> {
@@ -370,7 +315,7 @@ impl<'a> XmlTagEndWrapper<'a> {
 impl<'a> TagEnd for XmlTagEndWrapper<'a> {
     fn get_id(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(5 * 4));
+        cursor.set_position(5 * 4);
 
         Ok(cursor.read_u32::<LittleEndian>()?)
     }
@@ -379,20 +324,16 @@ impl<'a> TagEnd for XmlTagEndWrapper<'a> {
 #[allow(dead_code)]
 pub struct XmlTextWrapper<'a> {
     raw_data: &'a [u8],
-    header: ChunkHeader,
 }
 
 impl<'a> XmlTextWrapper<'a> {
-    pub fn new(raw_data: &'a [u8], header: ChunkHeader) -> Self {
-        XmlTextWrapper {
-            raw_data: raw_data,
-            header: header,
-        }
+    pub fn new(raw_data: &'a [u8]) -> Self {
+        XmlTextWrapper { raw_data: raw_data }
     }
 
     pub fn get_text_index(&self) -> Result<u32> {
         let mut cursor = Cursor::new(self.raw_data);
-        cursor.set_position(self.header.absolute(16));
+        cursor.set_position(16);
 
         cursor
             .read_u32::<LittleEndian>()

--- a/src/model/owned/package.rs
+++ b/src/model/owned/package.rs
@@ -78,7 +78,7 @@ impl OwnedBuf for PackageBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chunks::{PackageWrapper, ChunkHeader, ChunkLoaderStream, Chunk};
+    use chunks::{PackageWrapper, ChunkLoaderStream, Chunk};
     use model::owned::StringTableBuf;
     use std::io::Cursor;
     use std::iter;
@@ -91,9 +91,7 @@ mod tests {
         package.add_chunk(Box::new(some_other_chunk));
         let out = package.to_vec().unwrap();
 
-
-        let header = ChunkHeader::new(0, 288, out.len() as u32, 0x0200);
-        let wrapper = PackageWrapper::new(&out, header);
+        let wrapper = PackageWrapper::new(&out);
 
         assert_eq!(3, wrapper.get_id().unwrap());
         assert_eq!("com.test.test", wrapper.get_name().unwrap());

--- a/src/model/owned/resources.rs
+++ b/src/model/owned/resources.rs
@@ -48,8 +48,7 @@ mod tests {
 
         let out = resources.to_vec().unwrap();
 
-        let chunk_header = ChunkHeader::new(0, 8, 2 * 8, 0x0180);
-        let wrapper = ResourceWrapper::new(&out, chunk_header);
+        let wrapper = ResourceWrapper::new(&out);
 
         let expected_resources: Vec<u32> = vec![111, 222];
 
@@ -61,8 +60,7 @@ mod tests {
         let resources = ResourcesBuf::default();
         let out = resources.to_vec().unwrap();
 
-        let chunk_header = ChunkHeader::new(0, 8, (0 * 8) + 8, 0x0180);
-        let wrapper = ResourceWrapper::new(&out, chunk_header);
+        let wrapper = ResourceWrapper::new(&out);
 
         let expected_resources: Vec<u32> = vec![];
 
@@ -72,9 +70,8 @@ mod tests {
     #[test]
     fn identity() {
         let raw = raw_chunks::EXAMPLE_RESOURCES;
-        let chunk_header = ChunkHeader::new(0, 8, 24, 0x180);
 
-        let wrapper = ResourceWrapper::new(&raw, chunk_header);
+        let wrapper = ResourceWrapper::new(&raw);
         let owned = wrapper.to_buffer().unwrap();
         let new_raw = owned.to_vec().unwrap();
 

--- a/src/model/owned/string_table.rs
+++ b/src/model/owned/string_table.rs
@@ -182,8 +182,7 @@ mod tests {
     #[test]
     fn identity() {
         let raw = raw_chunks::EXAMPLE_STRING_TABLE;
-        let chunk_header = ChunkHeader::new(0, 8, raw.len() as u32, TOKEN_STRING_TABLE);
-        let wrapper = StringTableWrapper::new(&raw, chunk_header);
+        let wrapper = StringTableWrapper::new(&raw);
 
         let owned = wrapper.to_buffer().unwrap();
         let owned_as_vec = owned.to_vec().unwrap();

--- a/src/model/owned/table_type/mod.rs
+++ b/src/model/owned/table_type/mod.rs
@@ -132,8 +132,7 @@ mod tests {
 
     #[test]
     fn identity() {
-        let header = ChunkHeader::new(0, 68, raw_chunks::EXAMPLE_TABLE_TYPE.len() as u32, 0x201);
-        let wrapper = TableTypeWrapper::new(raw_chunks::EXAMPLE_TABLE_TYPE, header);
+        let wrapper = TableTypeWrapper::new(raw_chunks::EXAMPLE_TABLE_TYPE, 68);
         let _ = wrapper.get_entries();
 
         let owned = wrapper.to_buffer().unwrap();
@@ -144,11 +143,7 @@ mod tests {
 
     #[test]
     fn identity_with_mixed_complex_and_simple_entries() {
-        let header = ChunkHeader::new(0,
-                                      76,
-                                      raw_chunks::EXAMPLE_TABLE_TYPE_WITH_COMPLEX.len() as u32,
-                                      0x201);
-        let wrapper = TableTypeWrapper::new(raw_chunks::EXAMPLE_TABLE_TYPE_WITH_COMPLEX, header);
+        let wrapper = TableTypeWrapper::new(raw_chunks::EXAMPLE_TABLE_TYPE_WITH_COMPLEX, 76);
         let _ = wrapper.get_entries();
 
         let owned = wrapper.to_buffer().unwrap();

--- a/src/model/owned/table_type_spec.rs
+++ b/src/model/owned/table_type_spec.rs
@@ -79,8 +79,7 @@ mod tests {
 
     #[test]
     fn identity() {
-        let header = ChunkHeader::new(0, 16, raw_chunks::EXAMPLE_TYPE_SPEC.len() as u32, 0x202);
-        let wrapper = TypeSpecWrapper::new(raw_chunks::EXAMPLE_TYPE_SPEC, header);
+        let wrapper = TypeSpecWrapper::new(raw_chunks::EXAMPLE_TYPE_SPEC);
 
         let owned = wrapper.to_buffer().unwrap();
         let new_raw = owned.to_vec().unwrap();

--- a/src/model/owned/xml/namespace_end.rs
+++ b/src/model/owned/xml/namespace_end.rs
@@ -68,7 +68,6 @@ impl OwnedBuf for XmlNamespaceEndBuf {
 mod tests {
     use super::*;
     use chunks::XmlNamespaceEndWrapper;
-    use chunks::ChunkHeader;
     use test::compare_chunks;
     use raw_chunks::EXAMPLE_NAMESPACE_END;
 
@@ -81,8 +80,7 @@ mod tests {
 
     #[test]
     fn identity() {
-        let header = ChunkHeader::new(0, 8, 23, 0x101);
-        let wrapper = XmlNamespaceEndWrapper::new(EXAMPLE_NAMESPACE_END, header);
+        let wrapper = XmlNamespaceEndWrapper::new(EXAMPLE_NAMESPACE_END);
 
         let owned = wrapper.to_buffer().unwrap();
         let new_raw = owned.to_vec().unwrap();

--- a/src/model/owned/xml/namespace_start.rs
+++ b/src/model/owned/xml/namespace_start.rs
@@ -68,7 +68,6 @@ impl OwnedBuf for XmlNamespaceStartBuf {
 mod tests {
     use super::*;
     use chunks::XmlNamespaceStartWrapper;
-    use chunks::ChunkHeader;
     use test::{FakeStringTable, compare_chunks};
     use raw_chunks::EXAMPLE_NAMESPACE_START;
 
@@ -87,8 +86,7 @@ mod tests {
 
     #[test]
     fn identity() {
-        let header = ChunkHeader::new(0, 8, 23, 0x100);
-        let wrapper = XmlNamespaceStartWrapper::new(EXAMPLE_NAMESPACE_START, header);
+        let wrapper = XmlNamespaceStartWrapper::new(EXAMPLE_NAMESPACE_START);
 
         let owned = wrapper.to_buffer().unwrap();
         let new_raw = owned.to_vec().unwrap();

--- a/src/model/owned/xml/tag_end.rs
+++ b/src/model/owned/xml/tag_end.rs
@@ -68,8 +68,7 @@ mod tests {
     #[test]
     fn identity() {
         let raw = raw_chunks::EXAMPLE_TAG_END;
-        let chunk_header = ChunkHeader::new(0, 8, 24, 0x103);
-        let wrapper = XmlTagEndWrapper::new(&raw, chunk_header);
+        let wrapper = XmlTagEndWrapper::new(&raw);
 
         let owned = wrapper.to_buffer().unwrap();
         let new_raw = owned.to_vec().unwrap();

--- a/src/model/owned/xml/tag_start.rs
+++ b/src/model/owned/xml/tag_start.rs
@@ -160,8 +160,7 @@ mod tests {
     #[test]
     fn identity() {
         let raw = EXAMPLE_TAG_START;
-        let chunk_header = ChunkHeader::new(0, 16, EXAMPLE_TAG_START.len() as u32, 0x102);
-        let wrapper = XmlTagStartWrapper::new(raw, chunk_header);
+        let wrapper = XmlTagStartWrapper::new(raw);
 
         let owned = wrapper.to_buffer().unwrap();
         let new_raw = owned.to_vec().unwrap();

--- a/src/visitor/model.rs
+++ b/src/visitor/model.rs
@@ -96,7 +96,8 @@ impl<'a> ChunkVisitor<'a> for ModelVisitor<'a> {
             let entries_result = table_type.get_entries();
 
             if entries_result.is_err() {
-                error!("Error visiting table_type");
+                error!("Error visiting table_type: {}",
+                       entries_result.err().unwrap().description());
             } else {
                 let ventries = entries_result.unwrap();
                 for e in &ventries {


### PR DESCRIPTION
Until now, all the chunk wrappers could access to the whole buffer and had to do some arithmetics to do the access to the fields.
Also the decoders has been removed as they are not needed anymore.