### PR TITLE
Release/0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.26.2
+  - 1.30.0
 
 before_script:
   - export PATH=$PATH:~/.cargo/bin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abxml"
-version = "0.5.3"
+version = "0.6.0"
 license = "MIT/Apache-2.0"
 authors = [
     "Guillem Nieto <gnieto.talo@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 failure = "0.1.3"
-byteorder = "1.2.6"
+byteorder = "1.2.7"
 ansi_term = "0.11.0"
-log = "0.4.5"
+log = "0.4.6"
 env_logger = "0.5.13"
 zip = { version = "0.4.2", optional = true}
 encoding = "0.2.33"

--- a/examples/converter.rs
+++ b/examples/converter.rs
@@ -1,19 +1,18 @@
 extern crate abxml;
 extern crate byteorder;
 extern crate env_logger;
-#[macro_use]
 extern crate failure;
 extern crate log;
 extern crate zip;
 
-use std::env;
-use std::io::prelude::*;
-use std::io::Cursor;
+use std::{
+    env,
+    io::{prelude::*, Cursor},
+};
 
-use failure::{Error, ResultExt};
+use failure::{bail, Error, ResultExt};
 
-use abxml::encoder::Xml;
-use abxml::visitor::*;
+use abxml::{encoder::Xml, visitor::*};
 
 fn main() {
     env_logger::try_init().unwrap();
@@ -29,9 +28,6 @@ fn main() {
     }
 }
 
-// Most functions will return the `Result` type, imported from the
-// `errors` module. It is a typedef of the standard `Result` type
-// for which the error type is always our own `Error`.
 fn run() -> Result<(), Error> {
     let apk_path = match env::args().nth(1) {
         Some(path) => path,

--- a/examples/exporter.rs
+++ b/examples/exporter.rs
@@ -5,8 +5,7 @@ extern crate failure;
 extern crate log;
 extern crate zip;
 
-use std::env;
-use std::path::Path;
+use std::{env, path::Path};
 
 use failure::{Error, ResultExt};
 
@@ -26,9 +25,6 @@ fn main() {
     }
 }
 
-// Most functions will return the `Result` type, imported from the
-// `errors` module. It is a typedef of the standard `Result` type
-// for which the error type is always our own `Error`.
 fn run() -> Result<(), Error> {
     let apk_path = match env::args().nth(1) {
         Some(path) => path,

--- a/src/apk.rs
+++ b/src/apk.rs
@@ -1,10 +1,12 @@
 //! High level abstraction to easy the extraction to file system of APKs
 
-use std::fs;
-use std::io::{Read, Write};
-use std::path::Path;
+use std::{
+    fs,
+    io::{Read, Write},
+    path::Path,
+};
 
-use failure::{Error, ResultExt};
+use failure::{format_err, Error, ResultExt};
 use zip::read::ZipArchive;
 
 use decoder::*;

--- a/src/chunks/mod.rs
+++ b/src/chunks/mod.rs
@@ -135,9 +135,10 @@ impl<'a> Iterator for ChunkLoaderStream<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
     use super::*;
     use model::owned::{OwnedBuf, ResourcesBuf, StringTableBuf};
-    use std::io::Cursor;
 
     #[test]
     fn it_can_detect_loops() {

--- a/src/chunks/mod.rs
+++ b/src/chunks/mod.rs
@@ -12,15 +12,17 @@ pub mod table_type;
 mod table_type_spec;
 mod xml;
 
-pub use self::chunk_header::ChunkHeader;
-pub use self::package::PackageWrapper;
-pub use self::resource::ResourceWrapper;
-pub use self::string_table::{StringTableCache, StringTableWrapper};
-pub use self::table_type::{ConfigurationWrapper, TableTypeWrapper};
-pub use self::table_type_spec::TypeSpecWrapper;
-pub use self::xml::{
-    XmlNamespaceEndWrapper, XmlNamespaceStartWrapper, XmlTagEndWrapper, XmlTagStartWrapper,
-    XmlTextWrapper,
+pub use self::{
+    chunk_header::ChunkHeader,
+    package::PackageWrapper,
+    resource::ResourceWrapper,
+    string_table::{StringTableCache, StringTableWrapper},
+    table_type::{ConfigurationWrapper, TableTypeWrapper},
+    table_type_spec::TypeSpecWrapper,
+    xml::{
+        XmlNamespaceEndWrapper, XmlNamespaceStartWrapper, XmlTagEndWrapper, XmlTagStartWrapper,
+        XmlTextWrapper,
+    },
 };
 
 pub const TOKEN_STRING_TABLE: u16 = 0x0001;

--- a/src/chunks/package.rs
+++ b/src/chunks/package.rs
@@ -1,9 +1,8 @@
 use std::io::Cursor;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use encoding::codec::utf_16;
-use encoding::codec::utf_16::Little;
-use failure::Error;
+use encoding::codec::utf_16::{self, Little};
+use failure::{ensure, format_err, Error};
 
 #[derive(Debug)]
 pub struct PackageWrapper<'a> {

--- a/src/chunks/resource.rs
+++ b/src/chunks/resource.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use failure::Error;
+use failure::{ensure, Error};
 
 use model::owned::ResourcesBuf;
 

--- a/src/chunks/resource.rs
+++ b/src/chunks/resource.rs
@@ -53,8 +53,7 @@ impl<'a> ResourceWrapper<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use model::owned::OwnedBuf;
-    use model::owned::ResourcesBuf;
+    use model::owned::{OwnedBuf, ResourcesBuf};
 
     #[test]
     fn it_can_not_decode_a_buffer_with_an_invalid_size() {

--- a/src/chunks/string_table.rs
+++ b/src/chunks/string_table.rs
@@ -59,7 +59,7 @@ impl<'a> StringTableWrapper<'a> {
         let mut position = str_offset;
         let mut max_offset = 0;
 
-        for _ in 0..(idx + 1) {
+        for _ in 0..=idx {
             let current_offset = cursor.read_u32::<LittleEndian>()?;
             position = str_offset.wrapping_add(current_offset);
 

--- a/src/chunks/string_table.rs
+++ b/src/chunks/string_table.rs
@@ -1,15 +1,21 @@
-use std::cell::RefCell;
-use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::HashMap;
-use std::io::Cursor;
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    collections::{
+        hash_map::Entry::{Occupied, Vacant},
+        HashMap,
+    },
+    io::Cursor,
+    rc::Rc,
+};
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use encoding::codec::{utf_16, utf_8};
-use failure::Error;
+use failure::{ensure, format_err, Error};
 
-use model::owned::{Encoding as EncodingType, StringTableBuf};
-use model::StringTable;
+use model::{
+    owned::{Encoding as EncodingType, StringTableBuf},
+    StringTable,
+};
 
 #[derive(Debug)]
 pub struct StringTableWrapper<'a> {

--- a/src/chunks/table_type/configuration.rs
+++ b/src/chunks/table_type/configuration.rs
@@ -1,11 +1,9 @@
-use std::io::Cursor;
-use std::string::ToString;
+use std::{io::Cursor, string::ToString};
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use failure::Error;
+use failure::{bail, ensure, Error};
 
-use model::owned::ConfigurationBuf;
-use model::Configuration;
+use model::{owned::ConfigurationBuf, Configuration};
 
 #[derive(Debug)]
 pub struct ConfigurationWrapper<'a> {

--- a/src/chunks/table_type/mod.rs
+++ b/src/chunks/table_type/mod.rs
@@ -1,13 +1,14 @@
 use std::io::Cursor;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use failure::Error;
+use failure::{ensure, format_err, Error};
 
-use model::owned::{ComplexEntry, Entry, EntryHeader, SimpleEntry, TableTypeBuf};
-use model::TableType;
+use model::{
+    owned::{ComplexEntry, Entry, EntryHeader, SimpleEntry, TableTypeBuf},
+    TableType,
+};
 
-pub use self::configuration::ConfigurationWrapper;
-pub use self::configuration::Region;
+pub use self::configuration::{ConfigurationWrapper, Region};
 
 mod configuration;
 

--- a/src/chunks/table_type/mod.rs
+++ b/src/chunks/table_type/mod.rs
@@ -58,7 +58,7 @@ impl<'a> TableTypeWrapper<'a> {
         for i in 0..self.get_amount()? {
             let id = i & 0xFFFF;
 
-            if offsets[i as usize] == 0xFFFFFFFF {
+            if offsets[i as usize] == 0xFFFF_FFFF {
                 entries.push(Entry::Empty(id, id));
             } else {
                 let maybe_entry = Self::decode_entry(cursor, id)?;
@@ -81,15 +81,15 @@ impl<'a> TableTypeWrapper<'a> {
         let header_entry = EntryHeader::new(header_size, flags, key_index);
 
         if header_entry.is_complex() {
-            Self::decode_complex_entry(cursor, &header_entry, id)
+            Self::decode_complex_entry(cursor, header_entry, id)
         } else {
-            Self::decode_simple_entry(cursor, &header_entry, id)
+            Self::decode_simple_entry(cursor, header_entry, id)
         }
     }
 
     fn decode_simple_entry(
         cursor: &mut Cursor<&[u8]>,
-        header: &EntryHeader,
+        header: EntryHeader,
         id: u32,
     ) -> Result<Option<Entry>, Error> {
         cursor.read_u16::<LittleEndian>()?;
@@ -106,14 +106,14 @@ impl<'a> TableTypeWrapper<'a> {
 
     fn decode_complex_entry(
         cursor: &mut Cursor<&[u8]>,
-        header: &EntryHeader,
+        header: EntryHeader,
         id: u32,
     ) -> Result<Option<Entry>, Error> {
         let parent_entry = cursor.read_u32::<LittleEndian>()?;
         let value_count = cursor.read_u32::<LittleEndian>()?;
         let mut entries = Vec::with_capacity(value_count as usize);
 
-        if value_count == 0xFFFFFFFF {
+        if value_count == 0xFFFF_FFFF {
             return Ok(None);
         }
 

--- a/src/chunks/table_type_spec.rs
+++ b/src/chunks/table_type_spec.rs
@@ -1,10 +1,9 @@
 use std::io::Cursor;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use failure::Error;
+use failure::{ensure, Error};
 
-use model::owned::TableTypeSpecBuf;
-use model::TypeSpec;
+use model::{owned::TableTypeSpecBuf, TypeSpec};
 
 #[derive(Clone, Debug)]
 pub struct TypeSpecWrapper<'a> {

--- a/src/chunks/xml.rs
+++ b/src/chunks/xml.rs
@@ -1,13 +1,12 @@
-use std::io::Cursor;
-use std::rc::Rc;
+use std::{io::Cursor, rc::Rc};
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use failure::{Error, ResultExt};
+use failure::{ensure, Error, ResultExt};
 
-use model::owned::{
-    AttributeBuf, XmlNamespaceEndBuf, XmlNamespaceStartBuf, XmlTagEndBuf, XmlTagStartBuf,
+use model::{
+    owned::{AttributeBuf, XmlNamespaceEndBuf, XmlNamespaceStartBuf, XmlTagEndBuf, XmlTagStartBuf},
+    AttributeTrait, NamespaceEnd, NamespaceStart, StringTable, TagEnd, TagStart,
 };
-use model::{AttributeTrait, NamespaceEnd, NamespaceStart, StringTable, TagEnd, TagStart};
 
 #[derive(Debug)]
 pub struct XmlNamespaceStartWrapper<'a> {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -79,8 +79,9 @@ impl<'a> Decoder<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::io::Cursor;
+
+    use super::*;
 
     #[test]
     fn it_can_not_decode_an_empty_binary_xml() {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -4,9 +4,7 @@ use std::io::{Cursor, Read};
 
 use failure::{Error, ResultExt};
 
-use visitor::Executor;
-use visitor::ModelVisitor;
-use visitor::*;
+use visitor::{Executor, ModelVisitor, Resources, XmlVisitor};
 use STR_ARSC;
 
 #[derive(Debug)]

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,11 +1,12 @@
 //! Exports the decoded binary XMLs to string XMLs
 
-use std::io::Write;
-use std::ops::Deref;
+use std::{io::Write, ops::Deref};
 
 use failure::{Error, ResultExt};
-use xml::common::XmlVersion;
-use xml::writer::{EmitterConfig, EventWriter, XmlEvent};
+use xml::{
+    common::XmlVersion,
+    writer::{EmitterConfig, EventWriter, XmlEvent},
+};
 
 use model::{Element as AbxmlElement, Namespaces};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,9 @@
         unreadable_literal,
         stutter,
         cast_possible_truncation,
-        cast_precision_loss
+        cast_precision_loss,
+        similar_names,
+        shadow_unrelated,
     )
 )]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@
     allow(
         unreadable_literal,
         stutter,
-        similar_names,
         cast_possible_truncation,
         cast_precision_loss
     )
@@ -37,7 +36,6 @@
 
 extern crate byteorder;
 extern crate encoding;
-#[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate log;

--- a/src/model/builder.rs
+++ b/src/model/builder.rs
@@ -83,9 +83,10 @@ impl Xml {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
     use super::*;
     use model::owned::*;
-    use std::io::Cursor;
     use test::*;
     use visitor::Executor;
 

--- a/src/model/element.rs
+++ b/src/model/element.rs
@@ -1,7 +1,9 @@
-use std::collections::HashMap;
-use std::fmt::{self, Display, Formatter};
-use std::iter;
-use std::rc::Rc;
+use std::{
+    collections::HashMap,
+    fmt::{self, Display, Formatter},
+    iter,
+    rc::Rc,
+};
 
 #[derive(Default, Debug, PartialEq, Eq, Hash)]
 pub struct Tag {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -105,7 +105,7 @@ pub trait TagStart {
     fn get_line(&self) -> Result<u32, Error>;
     /// Return the content of the unknown field1
     fn get_field1(&self) -> Result<u32, Error>;
-    /// Return the namespace index. If there is no namespace, it will return 0xFFFFFFFF
+    /// Return the namespace index. If there is no namespace, it will return 0xFFFF_FFFF
     fn get_namespace_index(&self) -> Result<u32, Error>;
     /// Returns the index of the tag name on the string table
     fn get_element_name_index(&self) -> Result<u32, Error>;
@@ -121,7 +121,7 @@ pub trait TagStart {
 }
 
 pub trait AttributeTrait {
-    /// Return the namespace index. If there is no namespace, it will return 0xFFFFFFFF
+    /// Return the namespace index. If there is no namespace, it will return 0xFFFF_FFFF
     fn get_namespace(&self) -> Result<u32, Error>;
     /// Returns the index of the attribute on the string table
     fn get_name(&self) -> Result<u32, Error>;
@@ -138,7 +138,7 @@ pub trait AttributeTrait {
         let data_value = self.get_data()?;
         let class = self.get_class()?;
 
-        let value = if class == 0xFFFFFFFF {
+        let value = if class == 0xFFFF_FFFF {
             Value::new(data_type, data_value)?
         } else {
             Value::StringReference(class)

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,23 +1,24 @@
 //! Representations of logical structures found on android binary files
 
-use std::collections::{BTreeMap, HashMap};
-use std::rc::Rc;
+use std::{
+    collections::{BTreeMap, HashMap},
+    rc::Rc,
+};
 
 use failure::Error;
 
 use model::owned::Entry;
+use visitor::Origin;
 
 pub mod builder;
 mod element;
 pub mod owned;
 mod value;
 
-pub use self::element::Element;
-pub use self::element::ElementContainer;
-pub use self::element::Tag;
-pub use self::value::Value;
-
-use visitor::Origin;
+pub use self::{
+    element::{Element, ElementContainer, Tag},
+    value::Value,
+};
 
 pub type Namespaces = BTreeMap<String, String>;
 pub type Entries = HashMap<u32, Entry>;

--- a/src/model/owned/mod.rs
+++ b/src/model/owned/mod.rs
@@ -3,15 +3,13 @@ use std::fmt::Debug;
 use byteorder::{LittleEndian, WriteBytesExt};
 use failure::{Error, ResultExt};
 
-pub use self::package::PackageBuf;
-pub use self::resources::ResourcesBuf;
-pub use self::string_table::{Encoding, StringTableBuf};
-pub use self::table_type::{
-    ComplexEntry, ConfigurationBuf, Entry, EntryHeader, SimpleEntry, TableTypeBuf,
-};
-pub use self::table_type_spec::TableTypeSpecBuf;
-pub use self::xml::{
-    AttributeBuf, XmlNamespaceEndBuf, XmlNamespaceStartBuf, XmlTagEndBuf, XmlTagStartBuf,
+pub use self::{
+    package::PackageBuf,
+    resources::ResourcesBuf,
+    string_table::{Encoding, StringTableBuf},
+    table_type::{ComplexEntry, ConfigurationBuf, Entry, EntryHeader, SimpleEntry, TableTypeBuf},
+    table_type_spec::TableTypeSpecBuf,
+    xml::{AttributeBuf, XmlNamespaceEndBuf, XmlNamespaceStartBuf, XmlTagEndBuf, XmlTagStartBuf},
 };
 
 mod package;

--- a/src/model/owned/package.rs
+++ b/src/model/owned/package.rs
@@ -74,12 +74,11 @@ impl OwnedBuf for PackageBuf {
 
 #[cfg(test)]
 mod tests {
+    use std::{io::Cursor, iter};
+
     use super::*;
     use chunks::{Chunk, ChunkLoaderStream, PackageWrapper};
-    use model::owned::StringTableBuf;
-    use model::StringTable;
-    use std::io::Cursor;
-    use std::iter;
+    use model::{owned::StringTableBuf, StringTable};
 
     #[test]
     fn it_can_generate_a_chunk_with_the_given_data() {

--- a/src/model/owned/package.rs
+++ b/src/model/owned/package.rs
@@ -1,9 +1,8 @@
 use byteorder::{LittleEndian, WriteBytesExt};
-use failure::Error;
+use failure::{ensure, Error};
 
 use chunks::*;
-use encoding::codec::utf_16;
-use encoding::Encoding;
+use encoding::{codec::utf_16, Encoding};
 use model::owned::OwnedBuf;
 
 #[derive(Default, Debug)]

--- a/src/model/owned/string_table.rs
+++ b/src/model/owned/string_table.rs
@@ -152,6 +152,7 @@ impl StringTable for StringTableBuf {
 }
 
 #[cfg(test)]
+#[cfg_attr(feature = "cargo-clippy", allow(non_ascii_literal))]
 mod tests {
     use super::*;
     use raw_chunks;

--- a/src/model/owned/string_table.rs
+++ b/src/model/owned/string_table.rs
@@ -1,13 +1,14 @@
 use std::rc::Rc;
 
 use byteorder::{LittleEndian, WriteBytesExt};
-use encoding::codec::{utf_16, utf_8};
-use encoding::Encoding as EncodingTrait;
-use failure::Error;
+use encoding::{
+    codec::{utf_16, utf_8},
+    Encoding as EncodingTrait,
+};
+use failure::{bail, ensure, Error};
 
 use chunks::*;
-use model::owned::OwnedBuf;
-use model::StringTable;
+use model::{owned::OwnedBuf, StringTable};
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Encoding {

--- a/src/model/owned/table_type/entry.rs
+++ b/src/model/owned/table_type/entry.rs
@@ -20,11 +20,11 @@ impl EntryHeader {
         }
     }
 
-    pub fn is_complex(&self) -> bool {
+    pub fn is_complex(self) -> bool {
         (self.flags & MASK_COMPLEX) == MASK_COMPLEX
     }
 
-    pub fn get_key_index(&self) -> u32 {
+    pub fn get_key_index(self) -> u32 {
         self.key_index
     }
 }
@@ -145,7 +145,7 @@ impl ComplexEntry {
         // Children entry amount
         let children_amount = self.entries.len() as u32;
         if children_amount == 0 {
-            out.write_u32::<LittleEndian>(0xFFFFFFFF)?;
+            out.write_u32::<LittleEndian>(0xFFFF_FFFF)?;
         } else {
             out.write_u32::<LittleEndian>(self.entries.len() as u32)?;
         }

--- a/src/model/owned/table_type/entry.rs
+++ b/src/model/owned/table_type/entry.rs
@@ -1,5 +1,5 @@
 use byteorder::{LittleEndian, WriteBytesExt};
-use failure::Error;
+use failure::{format_err, Error};
 
 const MASK_COMPLEX: u16 = 0x0001;
 

--- a/src/model/owned/table_type/mod.rs
+++ b/src/model/owned/table_type/mod.rs
@@ -47,7 +47,7 @@ impl OwnedBuf for TableTypeBuf {
             let current_entry = e.to_vec()?;
 
             if e.is_empty() {
-                out.write_u32::<LittleEndian>(0xFFFFFFFF)?;
+                out.write_u32::<LittleEndian>(0xFFFF_FFFF)?;
             } else {
                 out.write_u32::<LittleEndian>(i)?;
                 i += current_entry.len() as u32;

--- a/src/model/owned/table_type/mod.rs
+++ b/src/model/owned/table_type/mod.rs
@@ -1,5 +1,5 @@
 use byteorder::{LittleEndian, WriteBytesExt};
-use failure::{ensure, format_err, Error};
+use failure::{format_err, Error};
 
 use model::{owned::OwnedBuf, TableType};
 

--- a/src/model/owned/table_type/mod.rs
+++ b/src/model/owned/table_type/mod.rs
@@ -1,14 +1,15 @@
 use byteorder::{LittleEndian, WriteBytesExt};
-use failure::Error;
+use failure::{ensure, format_err, Error};
 
-use model::owned::OwnedBuf;
-use model::TableType;
+use model::{owned::OwnedBuf, TableType};
 
 mod configuration;
 mod entry;
 
-pub use self::configuration::ConfigurationBuf;
-pub use self::entry::{ComplexEntry, Entry, EntryHeader, SimpleEntry};
+pub use self::{
+    configuration::ConfigurationBuf,
+    entry::{ComplexEntry, Entry, EntryHeader, SimpleEntry},
+};
 
 #[derive(Debug)]
 pub struct TableTypeBuf {

--- a/src/model/owned/table_type/mod.rs
+++ b/src/model/owned/table_type/mod.rs
@@ -102,8 +102,7 @@ impl TableType for TableTypeBuf {
 mod tests {
     use super::*;
     use chunks::*;
-    use model::owned::OwnedBuf;
-    use model::TableType;
+    use model::{owned::OwnedBuf, TableType};
     use raw_chunks;
     use test::compare_chunks;
 

--- a/src/model/owned/table_type_spec.rs
+++ b/src/model/owned/table_type_spec.rs
@@ -1,8 +1,7 @@
 use byteorder::{LittleEndian, WriteBytesExt};
-use failure::Error;
+use failure::{ensure, format_err, Error};
 
-use model::owned::OwnedBuf;
-use model::TypeSpec;
+use model::{owned::OwnedBuf, TypeSpec};
 
 #[derive(Debug)]
 pub struct TableTypeSpecBuf {

--- a/src/model/owned/table_type_spec.rs
+++ b/src/model/owned/table_type_spec.rs
@@ -1,5 +1,5 @@
 use byteorder::{LittleEndian, WriteBytesExt};
-use failure::{ensure, format_err, Error};
+use failure::{format_err, Error};
 
 use model::{owned::OwnedBuf, TypeSpec};
 

--- a/src/model/owned/xml/mod.rs
+++ b/src/model/owned/xml/mod.rs
@@ -4,8 +4,7 @@ mod namespace_start;
 mod tag_end;
 mod tag_start;
 
-pub use model::owned::xml::attribute::AttributeBuf;
-pub use model::owned::xml::namespace_end::XmlNamespaceEndBuf;
-pub use model::owned::xml::namespace_start::XmlNamespaceStartBuf;
-pub use model::owned::xml::tag_end::XmlTagEndBuf;
-pub use model::owned::xml::tag_start::XmlTagStartBuf;
+pub use model::owned::xml::{
+    attribute::AttributeBuf, namespace_end::XmlNamespaceEndBuf,
+    namespace_start::XmlNamespaceStartBuf, tag_end::XmlTagEndBuf, tag_start::XmlTagStartBuf,
+};

--- a/src/model/owned/xml/namespace_end.rs
+++ b/src/model/owned/xml/namespace_end.rs
@@ -62,7 +62,7 @@ impl OwnedBuf for XmlNamespaceEndBuf {
         let mut out = Vec::new();
 
         out.write_u32::<LittleEndian>(self.line)?;
-        out.write_u32::<LittleEndian>(0xFFFFFFFF)?;
+        out.write_u32::<LittleEndian>(0xFFFF_FFFF)?;
 
         Ok(out)
     }

--- a/src/model/owned/xml/namespace_end.rs
+++ b/src/model/owned/xml/namespace_end.rs
@@ -4,8 +4,10 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use failure::Error;
 
 use chunks::*;
-use model::owned::OwnedBuf;
-use model::{NamespaceEnd, StringTable};
+use model::{
+    owned::OwnedBuf,
+    {NamespaceEnd, StringTable},
+};
 
 #[derive(Debug, Copy, Clone)]
 pub struct XmlNamespaceEndBuf {

--- a/src/model/owned/xml/namespace_start.rs
+++ b/src/model/owned/xml/namespace_start.rs
@@ -4,8 +4,7 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use failure::Error;
 
 use chunks::*;
-use model::owned::OwnedBuf;
-use model::{NamespaceStart, StringTable};
+use model::{owned::OwnedBuf, NamespaceStart, StringTable};
 
 #[derive(Debug, Copy, Clone)]
 pub struct XmlNamespaceStartBuf {

--- a/src/model/owned/xml/namespace_start.rs
+++ b/src/model/owned/xml/namespace_start.rs
@@ -59,7 +59,7 @@ impl OwnedBuf for XmlNamespaceStartBuf {
         let mut out = Vec::new();
 
         out.write_u32::<LittleEndian>(self.line)?;
-        out.write_u32::<LittleEndian>(0xFFFFFFFF)?;
+        out.write_u32::<LittleEndian>(0xFFFF_FFFF)?;
 
         Ok(out)
     }

--- a/src/model/owned/xml/tag_end.rs
+++ b/src/model/owned/xml/tag_end.rs
@@ -24,7 +24,7 @@ impl OwnedBuf for XmlTagEndBuf {
         let mut out = Vec::new();
 
         // ??
-        out.write_u32::<LittleEndian>(0xFFFFFFFF)?;
+        out.write_u32::<LittleEndian>(0xFFFF_FFFF)?;
         // Id
         out.write_u32::<LittleEndian>(self.id)?;
 
@@ -37,7 +37,7 @@ impl OwnedBuf for XmlTagEndBuf {
         // Amount of writes
         out.write_u32::<LittleEndian>(3)?;
         // ??
-        out.write_u32::<LittleEndian>(0xFFFFFFFF)?;
+        out.write_u32::<LittleEndian>(0xFFFF_FFFF)?;
 
         Ok(out)
     }

--- a/src/model/owned/xml/tag_end.rs
+++ b/src/model/owned/xml/tag_end.rs
@@ -2,8 +2,7 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use failure::Error;
 
 use chunks::TOKEN_XML_TAG_END;
-use model::owned::OwnedBuf;
-use model::TagEnd;
+use model::{owned::OwnedBuf, TagEnd};
 
 #[derive(Debug, Copy, Clone)]
 pub struct XmlTagEndBuf {

--- a/src/model/owned/xml/tag_start.rs
+++ b/src/model/owned/xml/tag_start.rs
@@ -1,9 +1,11 @@
 use byteorder::{LittleEndian, WriteBytesExt};
-use failure::Error;
+use failure::{bail, Error};
 
 use chunks::*;
-use model::owned::{AttributeBuf, OwnedBuf};
-use model::{AttributeTrait, TagStart};
+use model::{
+    owned::{AttributeBuf, OwnedBuf},
+    AttributeTrait, TagStart,
+};
 
 /// Representation of a XML Tag start chunk
 #[derive(Debug)]

--- a/src/model/owned/xml/tag_start.rs
+++ b/src/model/owned/xml/tag_start.rs
@@ -134,7 +134,7 @@ mod tests {
         let attribute1 = AttributeBuf::new(1, 2, 3, 5, 6);
         let attribute2 = AttributeBuf::new(7, 8, 9, 11, 12);
 
-        let mut tag_start = XmlTagStartBuf::new(10, 22, 0xFFFFFFFF, 7, 5, 3);
+        let mut tag_start = XmlTagStartBuf::new(10, 22, 0xFFFF_FFFF, 7, 5, 3);
         tag_start.add_attribute(attribute1);
         tag_start.add_attribute(attribute2);
 
@@ -144,7 +144,7 @@ mod tests {
         assert_eq!(5, tag_start.get_field2().unwrap());
         assert_eq!(3, tag_start.get_class().unwrap());
         assert_eq!(2, tag_start.get_attributes_amount().unwrap());
-        assert_eq!(0xFFFFFFFF, tag_start.get_namespace_index().unwrap());
+        assert_eq!(0xFFFF_FFFF, tag_start.get_namespace_index().unwrap());
         let first_attribute = tag_start.get_attribute(0).unwrap();
         assert_eq!(1, first_attribute.get_namespace().unwrap());
         let third_attribute = tag_start.get_attribute(2);

--- a/src/model/value.rs
+++ b/src/model/value.rs
@@ -1,7 +1,6 @@
-use std::mem;
-use std::string::ToString;
+use std::{mem, string::ToString};
 
-use failure::Error;
+use failure::{format_err, Error};
 
 const TOKEN_TYPE_REFERENCE_ID: u8 = 0x01;
 const TOKEN_TYPE_ATTRIBUTE_REFERENCE_ID: u8 = 0x02;

--- a/src/model/value.rs
+++ b/src/model/value.rs
@@ -161,9 +161,9 @@ impl Value {
     fn complex(data: u32) -> f32 {
         // TODO: Clean this mess
         let mantissa = 0xffffff << 8;
-        let uvalue = data & mantissa;
-        let ivalue: i32 = unsafe { mem::transmute(uvalue) };
-        let m = ivalue as f32;
+        let u_value = data & mantissa;
+        let i_value: i32 = unsafe { mem::transmute(u_value) };
+        let m = i_value as f32;
         let mm = 1.0 / ((1 << 8) as f32);
 
         let radix = [

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use failure::Error;
+use failure::{bail, Error};
 
 use chunks::*;
 use model;
@@ -12,7 +12,7 @@ pub struct CounterChunkVisitor {
 }
 
 impl CounterChunkVisitor {
-    pub fn get_count(&self) -> u32 {
+    pub fn get_count(self) -> u32 {
         self.count
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,10 +1,10 @@
+use std::rc::Rc;
+
 use failure::Error;
 
 use chunks::*;
 use model;
-use std::rc::Rc;
-use visitor::ChunkVisitor;
-use visitor::Origin;
+use visitor::{ChunkVisitor, Origin};
 
 #[derive(Default, Debug, Copy, Clone)]
 pub struct CounterChunkVisitor {

--- a/src/visitor/mod.rs
+++ b/src/visitor/mod.rs
@@ -2,7 +2,7 @@
 use std::io::Cursor;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use failure::{Error, ResultExt};
+use failure::{bail, Error, ResultExt};
 
 use chunks::*;
 
@@ -10,10 +10,10 @@ pub mod model;
 mod print;
 mod xml;
 
-pub use self::model::ModelVisitor;
-pub use self::model::RefPackage;
-pub use self::model::Resources;
-pub use self::xml::XmlVisitor;
+pub use self::{
+    model::{ModelVisitor, RefPackage, Resources},
+    xml::XmlVisitor,
+};
 
 pub trait ChunkVisitor<'a> {
     fn visit_string_table(&mut self, _string_table: StringTableWrapper<'a>, _origin: Origin) {}

--- a/src/visitor/model.rs
+++ b/src/visitor/model.rs
@@ -1,20 +1,14 @@
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::rc::Rc;
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
-use failure::{Error, ResultExt};
+use failure::{format_err, Error, ResultExt};
 
 use chunks::*;
-use model::owned::Entry;
-use model::Library as LibraryTrait;
-use model::LibraryBuilder;
-use model::Resources as ResourcesTrait;
-use model::StringTable as StringTableTrait;
-use model::TypeSpec as TypeSpecTrait;
-use model::{Entries, Identifier};
+use model::{
+    owned::Entry, Entries, Identifier, Library as LibraryTrait, LibraryBuilder,
+    Resources as ResourcesTrait, StringTable as StringTableTrait, TypeSpec as TypeSpecTrait,
+};
 
-use super::ChunkVisitor;
-use super::Origin;
+use super::{ChunkVisitor, Origin};
 
 #[derive(Default, Debug)]
 pub struct ModelVisitor<'a> {

--- a/src/visitor/print.rs
+++ b/src/visitor/print.rs
@@ -1,10 +1,7 @@
 use chunks::*;
-use model::StringTable;
-use model::TableType;
-use model::TypeSpec;
+use model::{StringTable, TableType, TypeSpec};
 
-use super::ChunkVisitor;
-use super::Origin;
+use super::{ChunkVisitor, Origin};
 
 #[allow(dead_code)]
 #[derive(Debug)]

--- a/src/visitor/xml.rs
+++ b/src/visitor/xml.rs
@@ -1,20 +1,16 @@
-use std::cmp::Ordering;
-use std::collections::HashMap;
-use std::rc::Rc;
+use std::{cmp::Ordering, collections::HashMap, rc::Rc};
 
-use failure::{Error, ResultExt};
+use failure::{format_err, Error, ResultExt};
 
 use chunks::*;
 use encoder::Xml;
-use model::owned::SimpleEntry;
 use model::{
-    AttributeTrait, Element, ElementContainer, Identifier, Library, NamespaceStart, Namespaces,
-    Resources as ResourceTrait, StringTable, Tag, TagStart, Value,
+    owned::SimpleEntry, AttributeTrait, Element, ElementContainer, Identifier, Library,
+    NamespaceStart, Namespaces, Resources as ResourceTrait, StringTable, Tag, TagStart, Value,
 };
 use visitor::model::Resources;
 
-use super::ChunkVisitor;
-use super::Origin;
+use super::{ChunkVisitor, Origin};
 
 #[derive(Debug)]
 pub struct XmlVisitor<'a> {

--- a/src/visitor/xml.rs
+++ b/src/visitor/xml.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, collections::HashMap, rc::Rc};
 
-use failure::{format_err, Error, ResultExt};
+use failure::{bail, format_err, Error, ResultExt};
 
 use chunks::*;
 use encoder::Xml;
@@ -108,7 +108,7 @@ impl<'a> XmlVisitor<'a> {
                 .context(format_err!("could not read attribute {} ", i))?;
 
             let namespace_index = current_attribute.get_namespace()?;
-            if namespace_index != 0xFFFFFFFF {
+            if namespace_index != 0xFFFF_FFFF {
                 let namespace = (*string_table.get_string(namespace_index)?).clone();
                 let prefix = self
                     .namespaces
@@ -394,16 +394,16 @@ mod tests {
             let entry2 = Entry::Simple(simple_entry2);
 
             let simple_entry3 = SimpleEntry::new((2 << 24) | 4, 1, 1, 1 << 8);
-            let entry3 = Entry::Simple(simple_entry3.clone());
+            let entry3 = Entry::Simple(simple_entry3);
 
             let simple_entry4 = SimpleEntry::new((2 << 24) | 4, 456, 1, 1 << 8);
             let entry4 = Entry::Simple(simple_entry4);
 
             let simple_entry5 = SimpleEntry::new((2 << 24) | 5, 789, 1, 1 << 9);
-            let entry5 = Entry::Simple(simple_entry5.clone());
+            let entry5 = Entry::Simple(simple_entry5);
 
             let simple_entry6 = SimpleEntry::new((2 << 24) | 6, 123, 1, 1 << 10);
-            let entry6 = Entry::Simple(simple_entry6.clone());
+            let entry6 = Entry::Simple(simple_entry6);
 
             let mut ce1_childen_entries = Vec::new();
             ce1_childen_entries.push(simple_entry3);
@@ -490,7 +490,7 @@ mod tests {
 
             flags
                 .get(index as usize)
-                .map(|x| *x)
+                .cloned()
                 .ok_or_else(|| format_err!("flag out of bounds"))
         }
     }
@@ -501,9 +501,9 @@ mod tests {
 
     impl FakeResources {
         pub fn fake() -> Self {
-            let library = FakeLibrary::new();
-
-            FakeResources { library: library }
+            Self {
+                library: FakeLibrary::new(),
+            }
         }
     }
 

--- a/src/visitor/xml.rs
+++ b/src/visitor/xml.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, collections::HashMap, rc::Rc};
 
-use failure::{bail, format_err, Error, ResultExt};
+use failure::{format_err, Error, ResultExt};
 
 use chunks::*;
 use encoder::Xml;
@@ -372,12 +372,13 @@ impl AttributeHelper {
 
 #[cfg(test)]
 mod tests {
+    use failure::{bail, Error};
+
     use super::*;
-    use failure::Error;
-    use model::owned::{AttributeBuf, ComplexEntry, Entry, SimpleEntry};
-    use model::Entries;
-    use model::TypeSpec;
-    use model::{Library, LibraryBuilder, Resources, StringTable};
+    use model::{
+        owned::{AttributeBuf, ComplexEntry, Entry, SimpleEntry},
+        Entries, Library, LibraryBuilder, Resources, StringTable, TypeSpec,
+    };
     use test::FakeStringTable;
     use visitor::Origin;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -15,9 +15,9 @@ fn it_can_generate_a_decoder_from_a_buffer() {
     st.add_string("key".to_string());
     st.add_string("value".to_string());
 
-    let attribute = AttributeBuf::new(0xFFFFFFFF, 3, 0xFFFFFFFF, 3 << 24, 4);
+    let attribute = AttributeBuf::new(0xFFFF_FFFF, 3, 0xFFFF_FFFF, 3 << 24, 4);
 
-    let mut tag_start = XmlTagStartBuf::new(2, 0, 0xFFFFFFFF, 2, 0, 0);
+    let mut tag_start = XmlTagStartBuf::new(2, 0, 0xFFFF_FFFF, 2, 0, 0);
     tag_start.add_attribute(attribute);
 
     xml.push_owned(Box::new(st));


### PR DESCRIPTION
This release brings new syntax, makes it incompatible with Rust < 1.30.0, and brings performance improvement. The API is not 100% compatible with previous versions, so the version gets bumped to 0.6.0, per *semver*.