### PR TITLE
Some fixes and upgrade to Android 29 sdk

### DIFF
--- a/src/chunks/table_type/mod.rs
+++ b/src/chunks/table_type/mod.rs
@@ -118,13 +118,7 @@ impl<'a> TableTypeWrapper<'a> {
             return Ok(None);
         }
 
-        for j in 0..value_count {
-            debug!(
-                "Parsing value: {}/{} (@{})",
-                j,
-                value_count - 1,
-                cursor.position()
-            );
+        for _ in 0..value_count {
             let val_id = cursor.read_u32::<LittleEndian>()?;
             cursor.read_u16::<LittleEndian>()?;
             // Padding

--- a/src/chunks/xml.rs
+++ b/src/chunks/xml.rs
@@ -183,9 +183,11 @@ impl<'a> TagStart for XmlTagStartWrapper<'a> {
         let mut cursor = Cursor::new(self.raw_data);
         cursor.set_position(28);
 
-        Ok(cursor
-            .read_u32::<LittleEndian>()
-            .context("could not get data")?)
+        Ok(u32::from(
+            cursor
+                .read_u16::<LittleEndian>()
+                .context("could not get data")?,
+        ))
     }
 
     fn get_class(&self) -> Result<u32, Error> {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -84,7 +84,7 @@ pub trait LibraryBuilder<'a> {
 
     fn set_string_table(&mut self, string_table: Self::StringTable, origin: Origin);
     fn add_entries(&mut self, entries: Entries);
-    fn add_type_spec(&mut self, type_spec: Self::TypeSpec);
+    fn add_type_spec(&mut self, type_spec: Self::TypeSpec) -> Result<(), Error>;
 }
 
 pub trait Resources<'a> {

--- a/src/visitor/xml.rs
+++ b/src/visitor/xml.rs
@@ -484,7 +484,9 @@ mod tests {
 
         fn add_entries(&mut self, _: Entries) {}
 
-        fn add_type_spec(&mut self, _: Self::TypeSpec) {}
+        fn add_type_spec(&mut self, _: Self::TypeSpec) -> Result<(), Error> {
+            Ok(())
+        }
     }
 
     struct FakeTypeSpec;


### PR DESCRIPTION
This contains an upgrade to android 29 SDK and a couple of fixes:

- Use a HashMap instead of a Vector to store type specs: This fixes type specs which appears out-of-order or which are non-sequential.
- Use a proper width to store the number of attributes: This fixes some cases in which the returned number of attributes were extremely large, caused by a parsing error