### PR TITLE
build: exclude resources.arsc for package size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,6 @@ required-features = ["zip_decode"]
 [[example]]
 name = "converter"
 required-features = ["zip_decode"]
+
+[package]
+exclude = ["resources/resources.arsc"]


### PR DESCRIPTION
Hi, I use this crate in my package, And I find rust will include this file to package, it will increase about 30M in my package. So I suggest to remove for publish.